### PR TITLE
Feature: integrate coingecko

### DIFF
--- a/src/imports/api/Coin.ts
+++ b/src/imports/api/Coin.ts
@@ -1,0 +1,20 @@
+class Coin {
+    symbol: string;
+    name: string;
+    price: number;
+    imageUrl: string;
+
+    constructor(
+        _symbol: string,
+        _name: string,
+        _price: number,
+        _imageUrl: string,
+    ) {
+        this.symbol = _symbol;
+        this.name = _name;
+        this.price = _price;
+        this.imageUrl = _imageUrl;
+    }
+}
+
+export default Coin;

--- a/src/imports/api/Coin.ts
+++ b/src/imports/api/Coin.ts
@@ -1,20 +1,20 @@
 class Coin {
-    symbol: string;
-    name: string;
-    price: number;
-    imageUrl: string;
+  symbol: string;
+  name: string;
+  price: number;
+  imageUrl: string;
 
-    constructor(
-        _symbol: string,
-        _name: string,
-        _price: number,
-        _imageUrl: string,
-    ) {
-        this.symbol = _symbol;
-        this.name = _name;
-        this.price = _price;
-        this.imageUrl = _imageUrl;
-    }
+  constructor(
+    _symbol: string,
+    _name: string,
+    _price: number,
+    _imageUrl: string
+  ) {
+    this.symbol = _symbol;
+    this.name = _name;
+    this.price = _price;
+    this.imageUrl = _imageUrl;
+  }
 }
 
 export default Coin;

--- a/src/imports/api/CoinGeckoApi.ts
+++ b/src/imports/api/CoinGeckoApi.ts
@@ -1,0 +1,30 @@
+import Coin from './Coin';
+
+class CoinGeckoApi {
+    private static url: string = 'https://api.coingecko.com/api';
+
+    public static async getCoinsMarkets(
+        currency: string,
+        page: number,
+    ): Promise<Coin[]> {
+        const res = await fetch(
+            `${this.url}/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=250&page=${page}&sparkline=false&locale=en`,
+        );
+        const json = await res.json();
+
+        console.log(json);
+
+        return json.map(
+            (c: any) => new Coin(c.symbol, c.name, c.current_price, c.image),
+        );
+    }
+
+    public static async getTopCoins(currency: string): Promise<Coin[]> {
+        let topCoins = await this.getCoinsMarkets(currency, 1);
+        topCoins = topCoins.concat(await this.getCoinsMarkets(currency, 2));
+
+        return topCoins;
+    }
+}
+
+export default CoinGeckoApi;

--- a/src/imports/api/CoinGeckoApi.ts
+++ b/src/imports/api/CoinGeckoApi.ts
@@ -2,13 +2,11 @@ import Coin from './Coin';
 
 class CoinGeckoApi {
   private static url: string = 'https://api.coingecko.com/api';
+  private static cache: Coin[] | null = null;
 
-  public static async getCoinsMarkets(
-    currency: string,
-    page: number
-  ): Promise<Coin[]> {
+  public static async getCoinsMarkets(page: number): Promise<Coin[]> {
     const res = await fetch(
-      `${this.url}/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=250&page=${page}&sparkline=false&locale=en`
+      `${this.url}/v3/coins/markets?vs_currency=eur&order=market_cap_desc&per_page=250&page=${page}&sparkline=false&locale=en`
     );
     const json = await res.json();
 
@@ -17,11 +15,28 @@ class CoinGeckoApi {
     );
   }
 
-  public static async getTopCoins(currency: string): Promise<Coin[]> {
-    let topCoins = await this.getCoinsMarkets(currency, 1);
-    topCoins = topCoins.concat(await this.getCoinsMarkets(currency, 2));
+  public static async getTopCoins(): Promise<Coin[]> {
+    if (this.cache == null) {
+      let topCoins = await this.getCoinsMarkets(1);
+      topCoins = topCoins.concat(await this.getCoinsMarkets(2));
 
-    return topCoins;
+      for (let i = topCoins.length - 1; i > 0; i--) {
+        let j = Math.floor(Math.random() * (i + 1));
+        [topCoins[i], topCoins[j]] = [topCoins[j], topCoins[i]];
+      }
+
+      this.cache = topCoins;
+    }
+
+    return this.cache;
+  }
+
+  public static async getRandom(): Promise<Coin> {
+    if (this.cache == null) {
+      await this.getTopCoins();
+    }
+
+    return this.cache!.pop()!;
   }
 }
 

--- a/src/imports/api/CoinGeckoApi.ts
+++ b/src/imports/api/CoinGeckoApi.ts
@@ -1,30 +1,28 @@
 import Coin from './Coin';
 
 class CoinGeckoApi {
-    private static url: string = 'https://api.coingecko.com/api';
+  private static url: string = 'https://api.coingecko.com/api';
 
-    public static async getCoinsMarkets(
-        currency: string,
-        page: number,
-    ): Promise<Coin[]> {
-        const res = await fetch(
-            `${this.url}/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=250&page=${page}&sparkline=false&locale=en`,
-        );
-        const json = await res.json();
+  public static async getCoinsMarkets(
+    currency: string,
+    page: number
+  ): Promise<Coin[]> {
+    const res = await fetch(
+      `${this.url}/v3/coins/markets?vs_currency=${currency}&order=market_cap_desc&per_page=250&page=${page}&sparkline=false&locale=en`
+    );
+    const json = await res.json();
 
-        console.log(json);
+    return json.map(
+      (c: any) => new Coin(c.symbol, c.name, c.current_price, c.image)
+    );
+  }
 
-        return json.map(
-            (c: any) => new Coin(c.symbol, c.name, c.current_price, c.image),
-        );
-    }
+  public static async getTopCoins(currency: string): Promise<Coin[]> {
+    let topCoins = await this.getCoinsMarkets(currency, 1);
+    topCoins = topCoins.concat(await this.getCoinsMarkets(currency, 2));
 
-    public static async getTopCoins(currency: string): Promise<Coin[]> {
-        let topCoins = await this.getCoinsMarkets(currency, 1);
-        topCoins = topCoins.concat(await this.getCoinsMarkets(currency, 2));
-
-        return topCoins;
-    }
+    return topCoins;
+  }
 }
 
 export default CoinGeckoApi;

--- a/test/imports/api/CoinGeckoApi.test.ts
+++ b/test/imports/api/CoinGeckoApi.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals';
+import CoinGeckoApi from '../../../src/imports/api/CoinGeckoApi';
+
+test('getTopCoins', async () => {
+  const coins = await CoinGeckoApi.getTopCoins('eur');
+
+  expect(coins.length).toBe(500);
+});

--- a/test/imports/api/CoinGeckoApi.test.ts
+++ b/test/imports/api/CoinGeckoApi.test.ts
@@ -1,8 +1,23 @@
-import { expect, test } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import CoinGeckoApi from '../../../src/imports/api/CoinGeckoApi';
+import Coin from '../../../src/imports/api/Coin';
 
-test('getTopCoins', async () => {
-  const coins = await CoinGeckoApi.getTopCoins('eur');
+describe('CoinGeckoApi', () => {
+  test('getCoinsMarkets', async () => {
+    const coins = await CoinGeckoApi.getCoinsMarkets(1);
 
-  expect(coins.length).toBe(500);
+    expect(coins.length).toBe(250);
+  });
+
+  test('getTopCoins', async () => {
+    const coins = await CoinGeckoApi.getTopCoins();
+
+    expect(coins.length).toBe(500);
+  });
+
+  test('getRandom', async () => {
+    const coin = await CoinGeckoApi.getRandom();
+
+    expect(coin.constructor.name).toBe(Coin.name);
+  });
 });


### PR DESCRIPTION
Integration with the CoinGecko API to get cryptocurrencies price.

Use static array to avoid reaching the 30 requests limit.
Shuffle the array to create a simple random method.